### PR TITLE
Use centralized config to get env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ pom.xml.asc
 *.jar
 *.class
 /.lein-*
+!.lein-env.sample
 /.nrepl-port
 
 /resources/public/css

--- a/.lein-env.sample
+++ b/.lein-env.sample
@@ -1,0 +1,2 @@
+{:modernator-url "http://localhost:8080"
+ :database-url "postgres://localhost:5432/modernator"}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
   * [postgres](http://postgresapp.com/)
   * [leiningen](http://leiningen.org/)
-  * [forego](https://github.com/ddollar/forego) `brew install forego`
+  * [foreman](https://github.com/ddollar/foreman) `gem install foreman`
 
 # database
 
@@ -14,7 +14,7 @@
 
 # local dev
 
-  * `forego start`
+  * `foreman start`
   * navigate to http://localhost:8080
 
 ### Environment

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
   * `forego start`
   * navigate to http://localhost:8080
 
+### Environment
+
+To add or configure environment variables differently than [the default](src/clj/modernator/config.clj), simply copy the `.lein-env.sample` file and name it `.lein-env`.
+
 # deploy
 
   * Set up box with [postgres](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-postgresql-on-ubuntu-14-04)

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,8 @@
                  [com.draines/postal "1.11.3"]
                  [hiccup "1.0.4"]
                  [crypto-random "1.2.0"]
-                 [ragtime/ragtime.sql.files "0.3.8"]]
+                 [ragtime/ragtime.sql.files "0.3.8"]
+                 [environ "1.0.2"]]
   :main modernator.core
   :plugins [[ragtime/ragtime.lein "0.3.8"]
             [lein-cljsbuild "1.0.5"]

--- a/src/clj/modernator/config.clj
+++ b/src/clj/modernator/config.clj
@@ -1,0 +1,11 @@
+(ns modernator.config
+  (:require [environ.core :refer [env]]))
+
+(def overrides {:database-url (or (env :database-url) "postgresql://localhost:5432/modernator")
+                :modernator-url (or (env :modernator-url) "http://localhost:8080/")})
+
+(defn config
+  "A centralized map for environment variables and their overrides"
+  [env-var]
+  (let [env-vars (merge env overrides)]
+    (env-vars (keyword env-var))))

--- a/src/clj/modernator/models/mailer.clj
+++ b/src/clj/modernator/models/mailer.clj
@@ -1,10 +1,11 @@
 (ns modernator.models.mailer
-  (:require [postal.core :as postal]))
+  (:require [postal.core :as postal]
+            [modernator.config :refer [config]]))
 
 (defn send-message! [message]
-  (let [smtp-host (System/getenv "SMTP_HOST")
-        smtp-user (System/getenv "SMTP_USER")
-        smtp-pass (System/getenv "SMTP_PASS")]
+  (let [smtp-host (config :smtp-host)
+        smtp-user (config :smtp-user)
+        smtp-pass (config :smtp-pass)]
     (if smtp-host
       (postal/send-message
         {:host smtp-host

--- a/src/clj/modernator/models/main.clj
+++ b/src/clj/modernator/models/main.clj
@@ -1,10 +1,10 @@
 (ns modernator.models.main
   (:require [clojure.java.jdbc :as sql]
             [clojure.string :as str]
-            [crypto.random :as random]))
+            [crypto.random :as random]
+            [modernator.config :refer [config]]))
 
-(def spec (or (System/getenv "DATABASE_URL")
-              "postgresql://localhost:5432/modernator"))
+(def spec (config :database-url))
 
 (defn users-create [users]
   (apply sql/insert! spec :users (mapv #(assoc % :auth_token (random/url-part 20)) users)))

--- a/src/clj/modernator/views/main.clj
+++ b/src/clj/modernator/views/main.clj
@@ -1,6 +1,7 @@
 (ns modernator.views.main
   (require [hiccup.page :as page]
-           [hiccup.form :as form])
+           [hiccup.form :as form]
+           [modernator.config :refer [config]])
   (:gen-class))
 
 (defn index [_]
@@ -73,9 +74,9 @@
     [:body
      [:p "Hey There!"]
      [:p "We got a signup from your email on "
-      [:a {:href (str (System/getenv "MODERNATOR_URL"))} "Modernator"]
+      [:a {:href (str (config :modernator-url))} "Modernator"]
       ", So if you legitimately signed up for this, how about you "
-      [:a {:href (str (System/getenv "MODERNATOR_URL") "confirm-list/" auth-token)}
+      [:a {:href (str (config :modernator-url) "confirm-list/" auth-token)}
        "send invites to your list and start using modernator!"]]
      [:p "If you didn't sign up for this, sorry about that, looks like you got trolled."]
      [:p "Happy Collaborating,"]
@@ -87,7 +88,7 @@
      [:p "Hey There!"]
      [:p "You were added to a group to collaborate... on something..."]
      [:p "So why don't you go ahead and "
-      [:a {:href (str (System/getenv "MODERNATOR_URL") "confirm-user/" auth-token)}
+      [:a {:href (str (config :modernator-url) "confirm-user/" auth-token)}
        "start collaborating"]
       "."]
      [:p "Happy Collaborating,"]


### PR DESCRIPTION
Closes https://github.com/mojotech/modernator/issues/11
Closes https://github.com/mojotech/modernator/issues/24

By default it will read the global environment as well as your `profiles.clj`. Instead we can enforce the use of a `.lein-env` file like so:

``` clojure
{:some-specific-env-var "the specific env value"}
```
